### PR TITLE
Add HAXE_OUTPUT_FILE and HAXE_OUTPUT_PART to define.json

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -273,6 +273,20 @@
 		"doc": "Enable experimental features that are meant to be released on next Haxe version."
 	},
 	{
+		"name": "HaxeOutputFile",
+		"define": "HAXE_OUTPUT_FILE",
+		"doc": "Force the full output name of the executable/library without library prefix and debug suffix.",
+		"platforms": ["cpp"],
+		"params": ["name"]
+	},
+	{
+		"name": "HaxeOutputPart",
+		"define": "HAXE_OUTPUT_PART",
+		"doc": "Output name of the executable/library. (default: main class name)",
+		"platforms": ["cpp"],
+		"params": ["name"]
+	},
+	{
 		"name": "HlVer",
 		"define": "hl-ver",
 		"doc": "The HashLink version to target. (default: 1.10.0)",


### PR DESCRIPTION
Hxcpp uses these two defines to control the filename of the generated executable/library.